### PR TITLE
✅[CHORE] : 한판 승부 생성 메인 UI 변경사항 반영

### DIFF
--- a/Uni/Source/Scene/Battle/Cells/CollectionViewCell/BattleCollectionViewCell.swift
+++ b/Uni/Source/Scene/Battle/Cells/CollectionViewCell/BattleCollectionViewCell.swift
@@ -19,19 +19,22 @@ class BattleCollectionViewCell: UICollectionViewCell {
 //        }
 //    }
     
-    func update(_ status:Bool?){
-        if let status = status,
-            status {
-            self.contentView.layer.borderColor = UIColor.lightBlue500.cgColor
-            self.contentView.layer.borderWidth = 1
-        } else {
-            self.contentView.layer.borderWidth = 0
-        }
-    }
+//    func update(_ status:Bool?){
+//        if let status = status,
+//            status {
+//            self.contentView.layer.borderColor = UIColor.lightBlue500.cgColor
+//            self.contentView.layer.borderWidth = 1
+//        } else {
+//            self.contentView.layer.borderWidth = 0
+//        }
+//    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.setLayout()
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didCellTap))
+        self.contentView.addGestureRecognizer(tapGesture)
     }
     
     required init?(coder: NSCoder) {
@@ -75,10 +78,15 @@ class BattleCollectionViewCell: UICollectionViewCell {
         completion()
     }
     
-    private func updateCell() {
-        self.contentView.layer.borderColor = UIColor.lightBlue500.cgColor
-        self.contentView.layer.borderWidth = 1
+    @objc private func didCellTap() {
+        guard let completion = buttonTapCompletion else {return}
+        completion()
     }
+    
+//    private func updateCell() {
+//        self.contentView.layer.borderColor = UIColor.lightBlue500.cgColor
+//        self.contentView.layer.borderWidth = 1
+//    }
     
     private let iconImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
@@ -88,9 +96,9 @@ class BattleCollectionViewCell: UICollectionViewCell {
         $0.textColor = .gray600
     }
     private lazy var arrowButton = UIButton().then {
-        $0.addTarget(self,
-                     action: #selector(didArrowButtonTap),
-                     for: .touchUpInside)
+//        $0.addTarget(self,
+//                     action: #selector(didArrowButtonTap),
+//                     for: .touchUpInside)
         $0.tintColor = .gray250
         $0.setImage(SDSIcon.icChevron.withTintColor(.gray250, renderingMode: .alwaysTemplate), for: .normal)
     }

--- a/Uni/Source/Scene/Battle/Cells/CollectionViewCell/BattleWishCollectionViewCell.swift
+++ b/Uni/Source/Scene/Battle/Cells/CollectionViewCell/BattleWishCollectionViewCell.swift
@@ -25,25 +25,25 @@ class BattleWishCollectionViewCell: UICollectionViewCell {
     
     
     private func setLayout() {
-        self.contentView.addSubviews([couponView, creatButton])
+        self.contentView.addSubviews([couponView]) //, creatButton
         self.couponView.snp.remakeConstraints {
             $0.width.equalTo(UIScreen.main.bounds.width - 40)
             $0.top.centerX.equalToSuperview()
         }
-        self.creatButton.snp.makeConstraints {
-            $0.top.equalTo(self.couponView.snp.bottom).offset(32)
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(16)
-            $0.width.equalTo(UIScreen.main.bounds.width - 40)
-            $0.height.equalTo(48)
-        }
+//        self.creatButton.snp.makeConstraints {
+//            $0.top.equalTo(self.couponView.snp.bottom).offset(32)
+//            $0.centerX.equalToSuperview()
+//            $0.bottom.equalToSuperview().inset(16)
+//            $0.width.equalTo(UIScreen.main.bounds.width - 40)
+//            $0.height.equalTo(48)
+//        }
     }
     
     func addButtonGesture() {
         let tapGesture = UITapGestureRecognizer(target: self,
                                                 action: #selector(createButtonTap))
         tapGesture.delegate = self
-        self.creatButton.addGestureRecognizer(tapGesture)
+//        self.creatButton.addGestureRecognizer(tapGesture)
     }
     
     func setCouponConfig() {
@@ -52,13 +52,13 @@ class BattleWishCollectionViewCell: UICollectionViewCell {
     
     @objc private func createButtonTap() {
         guard let completion = makeButtonTapCompletion else {return}
-        completion(creatButton.buttonState)
+//        completion(creatButton.buttonState)
     }
     
     let couponView = BattleWishCouponView()
-    let creatButton = SDSButton(type: .fill, state: .disabled).then {
-        $0.setButtonTitle(title: "한판 승부 만들기")
-    }
+//    let creatButton = SDSButton(type: .fill, state: .disabled).then {
+//        $0.setButtonTitle(title: "한판 승부 만들기")
+//    }
 }
 extension BattleWishCollectionViewCell: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
@@ -67,6 +67,6 @@ extension BattleWishCollectionViewCell: UIGestureRecognizerDelegate {
 }
 extension BattleWishCollectionViewCell: CouponTextStateDelegate {
     func checkTextViewState(state: Bool) {
-        self.creatButton.buttonState = state ? .enabled: .disabled
+//        self.creatButton.buttonState = state ? .enabled: .disabled
     }
 }

--- a/Uni/Source/Scene/Battle/Components/BattleWishCouponView.swift
+++ b/Uni/Source/Scene/Battle/Components/BattleWishCouponView.swift
@@ -172,9 +172,9 @@ extension BattleWishCouponView: UITextViewDelegate {
         style.lineSpacing = 5
         textView.attributedText = NSAttributedString(string: textView.text, attributes: [NSAttributedString.Key.paragraphStyle: style])
 
-        if wishCouponTextView.text.count > 60 {
+        if wishCouponTextView.text.count > 54 {
             wishCouponTextView.deleteBackward()
-        } else if wishCouponTextView.text.count >= 55 {
+        } else if wishCouponTextView.text.count >= 54 {
             wishCouponTextBackgroundView.layer.borderColor = UIColor.red500.cgColor
             wishCountLabel.textColor = .red500
         }
@@ -187,7 +187,7 @@ extension BattleWishCouponView: UITextViewDelegate {
         
         if let text = wishCouponTextView.text {
             delegate?.getCouponText(text: text)
-            if text.count >= 55 {
+            if text.count >= 54 {
                 textViewStateDelegate?.checkTextViewState(state: false)
             } else {
                 textViewStateDelegate?.checkTextViewState(state: true)

--- a/Uni/Source/Scene/Battle/View/BattleView.swift
+++ b/Uni/Source/Scene/Battle/View/BattleView.swift
@@ -38,7 +38,7 @@ class BattleView: UIView {
                                          height: 78.adjusted)
         layout.minimumLineSpacing = 9
         layout.minimumInteritemSpacing = 9
-        layout.sectionInset = .init(top: 0, left: 0, bottom: 16, right: 0)
+        layout.sectionInset = .init(top: 0, left: 0, bottom: 48, right: 0)
         self.collectionView.setCollectionViewLayout(layout, animated: false)
         self.collectionView.contentInset = .init(top: 0, left: 20, bottom: 0, right: 20)
     }

--- a/Uni/Source/Scene/Battle/ViewController/BattleViewController.swift
+++ b/Uni/Source/Scene/Battle/ViewController/BattleViewController.swift
@@ -48,7 +48,7 @@ class BattleViewController: BaseViewController {
                 strongSelf.resetSelectCellArray()
                 strongSelf.selectedCellArray[index].toggle()
                 strongSelf.selectedBattleId = strongSelf.battleData[index].id
-                strongSelf.isCanMakeSession()
+//                strongSelf.isCanMakeSession()
                 strongSelf.battleView.collectionView.reloadData()
             }
         }
@@ -60,19 +60,19 @@ class BattleViewController: BaseViewController {
         }
     }
     
-    private func isCanMakeSession() {
-        if self.selectedBattleId != nil && self.missionContent.count <= 54{
-            self.changeButtonState(state: .enabled)
-        } else {
-            self.changeButtonState(state: .disabled)
-        }
-        self.battleView.collectionView.reloadData()
-    }
-    
-    private func changeButtonState(state: SDSButtonState) {
-        guard let cell = battleView.collectionView.cellForItem(at: .init(row: 0, section: 1)) as? BattleWishCollectionViewCell else { return }
-        cell.creatButton.buttonState = state
-    }
+//    private func isCanMakeSession() {
+//        if self.selectedBattleId != nil && self.missionContent.count <= 54{
+//            self.changeButtonState(state: .enabled)
+//        } else {
+//            self.changeButtonState(state: .disabled)
+//        }
+//        self.battleView.collectionView.reloadData()
+//    }
+//
+//    private func changeButtonState(state: SDSButtonState) {
+//        guard let cell = battleView.collectionView.cellForItem(at: .init(row: 0, section: 1)) as? BattleWishCollectionViewCell else { return }
+////        cell.creatButton.buttonState = state
+//    }
     
     private func naviagationButtonTap() {
         self.battleView.navigationBar.rightBarRightButtonItemCompletionHandler = { [weak self] in
@@ -110,7 +110,7 @@ class BattleViewController: BaseViewController {
                 }
                 strongSelf.selectedCellArray.append(false)
             }
-            strongSelf.isCanMakeSession()
+//            strongSelf.isCanMakeSession()
             strongSelf.battleView.collectionView.reloadData()
             strongSelf.view.removeIndicator()
         }
@@ -197,9 +197,9 @@ extension BattleViewController: UICollectionViewDataSource {
                                                         withReuseIdentifier: SectionView.reuseIdentifier, for: indexPath) as? SectionView else {return UICollectionReusableView()}
         switch indexPath.section {
         case 0:
-            headerView.bindText(title: "미션 카테고리 선택하기", subTitle: "더보기 버튼을 눌러 설명을 볼 수 있어요")
-        default:
             headerView.bindText(title: "소원 정하기", subTitle: nil)
+        default:
+            headerView.bindText(title: "미션 카테고리 선택하기", subTitle: "원하는 카테고리를 선택해 보세요")
         }
         return headerView
     }
@@ -207,58 +207,59 @@ extension BattleViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         switch section{
         case 0:
-            return battleData.count
-        default:
             return 1
+        default:
+            return battleData.count
         }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch indexPath.section {
         case 0:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BattleWishCollectionViewCell.reuseIdentifier, for: indexPath) as? BattleWishCollectionViewCell else {return UICollectionViewCell()}
+            cell.couponView.delegate = self
+            cell.makeButtonTapCompletion = { [weak self] state in
+                guard let strongSelf = self else {return}
+                if state == .enabled {
+                    guard let strongSelf = self else {return}
+                    let alert = strongSelf.view.showAlert(title: "설정된 내용으로 승부를 만들까요?",
+                                                          message: "한번 설정한 내용은 변경할 수 없어요",
+                                                          cancelButtonMessage: "취소",
+                                                          okButtonMessage: "만들기",
+                                                          type: .alert)
+                    
+                    alert.cancelButtonTapCompletion = { [weak self] in
+                        guard let strongSelf = self else {return}
+                        strongSelf.view.hideAlert(view: alert)
+                    }
+                    
+                    alert.okButtonTapCompletion = { [weak self] in
+                        strongSelf.makeBattle { [weak self] roundId in
+                            guard let strongSelf = self else {return}
+                            let battleHistoryVC = BattleHistoryViewController()
+                            battleHistoryVC.modalPresentationStyle = .overFullScreen
+                            guard let pvc = strongSelf.presentingViewController else { return }
+                            strongSelf.dismiss(animated: true) {
+                                pvc.present(battleHistoryVC, animated: true, completion: nil)
+                            }
+                        }
+                    }
+                }
+            }
+            return cell
+        default: // section 1
+            
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BattleCollectionViewCell.reuseIdentifier, for: indexPath) as? BattleCollectionViewCell else {return UICollectionViewCell()}
             cell.bindText(iconImage: battleData[indexPath.row].image,
                           title: battleData[indexPath.row].title)
-            cell.update(selectedCellArray[indexPath.item])
+//            cell.update(selectedCellArray[indexPath.item])
             cell.buttonTapCompletion = { [weak self] in
                 guard let strongSelf = self else {return}
                 strongSelf.cellButtonTap(battleId: strongSelf.battleData[indexPath.row].id)
             }
             
             return cell
-        default: // section 1
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BattleWishCollectionViewCell.reuseIdentifier, for: indexPath) as? BattleWishCollectionViewCell else {return UICollectionViewCell()}
-            cell.couponView.delegate = self
-            cell.makeButtonTapCompletion = { [weak self] state in
-                guard let strongSelf = self else {return}
-                if state == .enabled {
-                        guard let strongSelf = self else {return}
-                        let alert = strongSelf.view.showAlert(title: "설정된 내용으로 승부를 만들까요?",
-                                                              message: "한번 설정한 내용은 변경할 수 없어요",
-                                                              cancelButtonMessage: "취소",
-                                                              okButtonMessage: "만들기",
-                                                              type: .alert)
-                        
-                        alert.cancelButtonTapCompletion = { [weak self] in
-                            guard let strongSelf = self else {return}
-                            strongSelf.view.hideAlert(view: alert)
-                        }
-                        
-                        alert.okButtonTapCompletion = { [weak self] in
-                            strongSelf.makeBattle { [weak self] roundId in
-                                guard let strongSelf = self else {return}
-                                let battleHistoryVC = BattleHistoryViewController()
-                                battleHistoryVC.modalPresentationStyle = .overFullScreen
-                                guard let pvc = strongSelf.presentingViewController else { return }
-                                strongSelf.dismiss(animated: true) {
-                                  pvc.present(battleHistoryVC, animated: true, completion: nil)
-                                }
-                            }
-                        }
-                        
-                }
-            }
-            return cell
+
         }
     }
     
@@ -266,7 +267,7 @@ extension BattleViewController: UICollectionViewDataSource {
         self.resetSelectCellArray()
         self.selectedCellArray[indexPath.item].toggle()
         self.selectedBattleId = battleData[indexPath.row].id
-        self.isCanMakeSession()
+//        self.isCanMakeSession()
         collectionView.reloadData()
         return true
     }
@@ -276,10 +277,10 @@ extension BattleViewController: UICollectionViewDelegateFlowLayout {
         switch section {
         case 0:
             return CGSize(width: UIScreen.main.bounds.width,
-                          height: 82)
+                          height: 56)
         default:
             return CGSize(width: UIScreen.main.bounds.width,
-                          height: 56)
+                          height: 82)
         }
     }
 }

--- a/Uni/Source/Scene/BattleCategory/ViewController/SelectBattleCategoryViewController.swift
+++ b/Uni/Source/Scene/BattleCategory/ViewController/SelectBattleCategoryViewController.swift
@@ -50,6 +50,7 @@ class SelectBattleCategoryViewController: BaseViewController {
     let battleRepository = BattleRepository()
     var battleId: Int = 0
     var selectButtonCompletion: ((Int) -> Void)?
+    var cellTapCompletion: ((Int) -> Void)?
 }
 
 extension SelectBattleCategoryViewController: UIGestureRecognizerDelegate {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #147 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- ui 변경 반영
<img src="https://github.com/U-is-Ni-in-Korea/iOS-United/assets/73579035/32a2725c-2b29-437d-89b3-c457ce11cbcf" width=300></img>

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 우선 제가 작성했던 코드가 아니어서 코드 정리 안하고 주석처리하면서 필요한 코드 집어넣었습니다.. 추후에 린트 적용하면서 수정해야 할 것 같습니다!
- 소원 작성 글자수가 초과된 상황에서 카테고리를 선택했을 때 뜨는 토스트 메시지(카테고리 설명으로 넘어가지 않음)는 아직 구현 못했습니다
- 원래 여기 있던 '한판 승부 만들기' 버튼이 카테고리 설명 부분에 생기는걸로 바뀌어서 지금 승부 안만들어짐!!!!!!!!!!
