### PR TITLE
🔨[FIX] : 한판 승부 진행 화면 중 실패 버튼이 액션이 되지 않는 이슈 해결

### DIFF
--- a/Uni/Source/Scene/Battle/ViewController/BattleHistoryViewController.swift
+++ b/Uni/Source/Scene/Battle/ViewController/BattleHistoryViewController.swift
@@ -21,6 +21,7 @@ final class BattleHistoryViewController: BaseViewController {
         setLayout()
         addNavigationButtonAction()
         addMissionCompleteButtonAction()
+        addmissionFailureButtonAction()
     }
     // MARK: - Setting
     override func setConfig() {
@@ -62,7 +63,7 @@ final class BattleHistoryViewController: BaseViewController {
         }
         .store(in: &cancellables)
     }
-    private func missionFailureButtonAction() {
+    private func addmissionFailureButtonAction() {
         battleHistoryViewData.missionFailureButtonTapPublisher.sink { [weak self] _ in
             guard let self = self else { return }
             self.view.showIndicator()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #178 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
한판 승부 진행 화면 중 실패 버튼이 액션이 되지 않는 이슈 해결

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 메서드를 만들고 호출을 하지 않았습니다. 
