### PR TITLE
💊[TEST]: BattleHistoryResultViewModelTest 코드 작성

### DIFF
--- a/SparkleAppTests/BattleHistoryResultTests/BattleHistoryResultViewModelTests.swift
+++ b/SparkleAppTests/BattleHistoryResultTests/BattleHistoryResultViewModelTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Combine
+import Alamofire
+@testable import Uni
+
+final class BattleHistoryResultViewModelTests: XCTestCase {
+    var sut: BattleHistoryResultViewModel!
+    var getServiceCombine: GetServiceCombine!
+    var battleHistoryResult: [BattleHistoryResultDTO]!
+    var urlString: String!
+    var cancellables: Set<AnyCancellable> = []
+    override func setUpWithError() throws {
+        let config = URLSessionConfiguration.af.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let urlSesstion = Session(configuration: config)
+        sut = BattleHistoryResultViewModel(battleHistoryResultUsecase: BattleHistoryResultUseCase(battleHistoryResultRepository: BattleHistoryResultRepository(service: GetServiceCombine(session: urlSesstion))))
+        urlString = Config.baseURL + "api/history"
+    }
+    override func tearDownWithError() throws {
+        sut = nil
+        getServiceCombine = nil
+        battleHistoryResult = nil
+        urlString = nil
+        cancellables = []
+    }
+    func test_BattleHistoryResultViewModel에_ViewLoad됐을때_battleHistoryResultData가반환_테스트() {
+        // Expectation
+        let expectation = expectation(description: "BattleHistoryResultDTO 데이터 조회 성공")
+        // Given
+        battleHistoryResult = BattleHistoryResultConstants.battleHistoryResultData
+        let jsonString = BattleHistoryResultConstants.battleHistoryResultJsonString
+        MockURLProtocol.stubResponseData = jsonString.data(using: .utf8)
+        let viewLoadTrigger = PassthroughSubject<Void, Never>()
+        var expectationResults: [BattleHistoryResultDTO]?
+        let output = sut.transform(input: BattleHistoryResultViewModel.Input(viewLoad: viewLoadTrigger.eraseToAnyPublisher()))
+        output.loadBattleHistoryResultData
+            .sink { [weak self] completion in
+                guard let self = self else { return }
+                switch completion {
+                case .failure(let errorType):
+                    XCTFail("테스트 실패 - 실패가 나와선 안되는 케이스\(errorType)")
+                case .finished:
+                    break
+                }
+            } receiveValue: { data in
+                expectationResults = data
+                expectation.fulfill()
+            }.store(in: &cancellables)
+        // When
+        viewLoadTrigger.send()
+        wait(for: [expectation], timeout: 5)
+        // Then
+        XCTAssertEqual(expectationResults, battleHistoryResult)
+    }
+    func test_BattleHistoryResultViewModel에_ViewLoad됐을때_에러타입_DisConnected에러가반환_테스트() {
+        // Expectation
+        let expectation = self.expectation(description: "disConnected 에러를 받게 됨")
+        // Given
+        MockURLProtocol.stubResponseData = BattleHistoryResultConstants.battleHistoryResultDisconnectedJsonString.data(using: .utf8)
+        let viewLoadTrigger = PassthroughSubject<Void, Never>()
+        var expectationResults: ErrorType?
+        let output = sut.transform(input: BattleHistoryResultViewModel.Input(viewLoad: viewLoadTrigger.eraseToAnyPublisher()))
+        output.loadBattleHistoryResultData
+            .sink { [weak self] completion in
+                guard let self = self else { return }
+                switch completion {
+                case .failure(let errorType):
+                    expectationResults = errorType
+                    expectation.fulfill()
+                case .finished:
+                    return
+                }
+            } receiveValue: { data in
+                XCTFail("테스트 실패 - data가 실행되지 말아야함 \(data)")
+            }.store(in: &cancellables)
+        // When
+        viewLoadTrigger.send()
+        wait(for: [expectation], timeout: 5)
+        // Then
+        XCTAssertEqual(expectationResults, ErrorType.disconnected)
+    }
+}

--- a/Uni.xcodeproj/project.pbxproj
+++ b/Uni.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		A5BC3A682B452F4D00FD369C /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BC3A672B452F4D00FD369C /* MockURLProtocol.swift */; };
 		A5BC3A6A2B46841800FD369C /* BattleHistoryItemViewDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BC3A692B46841800FD369C /* BattleHistoryItemViewDataTests.swift */; };
 		A5BC3A6E2B46874800FD369C /* BattleHistoryResultConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BC3A6D2B46874800FD369C /* BattleHistoryResultConstants.swift */; };
+		A5BC3A7A2B46E14500FD369C /* BattleHistoryResultViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BC3A792B46E14500FD369C /* BattleHistoryResultViewModelTests.swift */; };
 		A5C23DDF2ABAB96900800190 /* BattleProgressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C23DDE2ABAB96900800190 /* BattleProgressViewModel.swift */; };
 		A5C6D3862ACD606500C01CA9 /* BattleResultViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C6D3852ACD606500C01CA9 /* BattleResultViewData.swift */; };
 		A5F26AB02B09EF870026BB58 /* BattleMemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F26AAF2B09EF870026BB58 /* BattleMemoView.swift */; };
@@ -442,6 +443,7 @@
 		A5BC3A672B452F4D00FD369C /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
 		A5BC3A692B46841800FD369C /* BattleHistoryItemViewDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BattleHistoryItemViewDataTests.swift; sourceTree = "<group>"; };
 		A5BC3A6D2B46874800FD369C /* BattleHistoryResultConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BattleHistoryResultConstants.swift; sourceTree = "<group>"; };
+		A5BC3A792B46E14500FD369C /* BattleHistoryResultViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BattleHistoryResultViewModelTests.swift; sourceTree = "<group>"; };
 		A5C23DDE2ABAB96900800190 /* BattleProgressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BattleProgressViewModel.swift; sourceTree = "<group>"; };
 		A5C6D3852ACD606500C01CA9 /* BattleResultViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BattleResultViewData.swift; sourceTree = "<group>"; };
 		A5F26AAF2B09EF870026BB58 /* BattleMemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BattleMemoView.swift; sourceTree = "<group>"; };
@@ -1794,6 +1796,7 @@
 				A5BC3A632B451D6D00FD369C /* Constants */,
 				A5BC3A5B2B4431B100FD369C /* BattleHistoryResultServiceTests.swift */,
 				A5BC3A692B46841800FD369C /* BattleHistoryItemViewDataTests.swift */,
+				A5BC3A792B46E14500FD369C /* BattleHistoryResultViewModelTests.swift */,
 			);
 			path = BattleHistoryResultTests;
 			sourceTree = "<group>";
@@ -2216,6 +2219,7 @@
 				A5BC3A682B452F4D00FD369C /* MockURLProtocol.swift in Sources */,
 				A5BC3A5C2B4431B100FD369C /* BattleHistoryResultServiceTests.swift in Sources */,
 				A5BC3A652B451D8700FD369C /* BattleHistoryResultConstants.swift in Sources */,
+				A5BC3A7A2B46E14500FD369C /* BattleHistoryResultViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  #267 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- BattleHistoryResultViewModelTest 테스트 코드 작성

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 두 가지의 테스트 코드를 작성하였습니다.
- 1. ViewModel에서 VIewLoadTrigger 시에 데이터가 들어오는지 확인
``` swift
func test_BattleHistoryResultViewModel에_ViewLoad됐을때_battleHistoryResultData가반환_테스트() {
        // Expectation
        let expectation = expectation(description: "BattleHistoryResultDTO 데이터 조회 성공")
        // Given
        battleHistoryResult = BattleHistoryResultConstants.battleHistoryResultData
        let jsonString = BattleHistoryResultConstants.battleHistoryResultJsonString
        MockURLProtocol.stubResponseData = jsonString.data(using: .utf8)
        let viewLoadTrigger = PassthroughSubject<Void, Never>()
        var expectationResults: [BattleHistoryResultDTO]?
        let output = sut.transform(input: BattleHistoryResultViewModel.Input(viewLoad: viewLoadTrigger.eraseToAnyPublisher()))
        output.loadBattleHistoryResultData
            .sink { [weak self] completion in
                guard let self = self else { return }
                switch completion {
                case .failure(let errorType):
                    XCTFail("테스트 실패 - 실패가 나와선 안되는 케이스\(errorType)")
                case .finished:
                    break
                }
            } receiveValue: { data in
                expectationResults = data
                expectation.fulfill()
            }.store(in: &cancellables)
        // When
        viewLoadTrigger.send()
        wait(for: [expectation], timeout: 5)
        // Then
        XCTAssertEqual(expectationResults, battleHistoryResult)
    }
```
- 2. ViewModel에서 ViewLoadTrigger 시에 에러가 들어오는지 확인

``` swift
func test_BattleHistoryResultViewModel에_ViewLoad됐을때_에러타입_DisConnected에러가반환_테스트() {
        // Expectation
        let expectation = self.expectation(description: "disConnected 에러를 받게 됨")
        // Given
        MockURLProtocol.stubResponseData = BattleHistoryResultConstants.battleHistoryResultDisconnectedJsonString.data(using: .utf8)
        let viewLoadTrigger = PassthroughSubject<Void, Never>()
        var expectationResults: ErrorType?
        let output = sut.transform(input: BattleHistoryResultViewModel.Input(viewLoad: viewLoadTrigger.eraseToAnyPublisher()))
        output.loadBattleHistoryResultData
            .sink { [weak self] completion in
                guard let self = self else { return }
                switch completion {
                case .failure(let errorType):
                    expectationResults = errorType
                    expectation.fulfill()
                case .finished:
                    return
                }
            } receiveValue: { data in
                XCTFail("테스트 실패 - data가 실행되지 말아야함 \(data)")
            }.store(in: &cancellables)
        // When
        viewLoadTrigger.send()
        wait(for: [expectation], timeout: 5)
        // Then
        XCTAssertEqual(expectationResults, ErrorType.disconnected)
    }
```